### PR TITLE
Fix quote form endpoint to match deployed Supabase function

### DIFF
--- a/submit-v2.js
+++ b/submit-v2.js
@@ -19,7 +19,7 @@ document.getElementById("quoteForm").addEventListener("submit", async (e) => {
   };
 
   try {
-    const res = await fetch("https://zzigzylypifjokskehkn.supabase.co/functions/v1/send-quote", {
+    const res = await fetch("https://zzigzylypifjokskehkn.supabase.co/functions/v1/send-quote-email", {
       method: "POST",
       headers: {
         "Content-Type": "application/json"


### PR DESCRIPTION
- Updated fetch URL in submit-v2.js to use `send-quote-email` instead of `send-quote`
- This matches the deployed Supabase Edge Function and resolves CORS + 404 errors
